### PR TITLE
fix: handle null or empty query parameters within handlers

### DIFF
--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterRequiredQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterRequiredQueryHandlerTests.cs
@@ -19,7 +19,6 @@ public class ParameterRequiredQueryHandlerTests
     public async Task Handle_RequiredMissingParam()
     {
         var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
@@ -29,7 +28,7 @@ public class ParameterRequiredQueryHandlerTests
                 Name = "Param1",
                 Required = true
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -44,7 +43,6 @@ public class ParameterRequiredQueryHandlerTests
     public async Task Handle_OptionalMissingParam()
     {
         var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
@@ -54,7 +52,7 @@ public class ParameterRequiredQueryHandlerTests
                 Name = "Param1",
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -69,13 +67,12 @@ public class ParameterRequiredQueryHandlerTests
     public async Task Handle_NullParam()
     {
         var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
             Name = "UnitTest",
             Param = null,
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.That(response, Is.InstanceOf<ValidatorNode?>());
     }
@@ -84,7 +81,6 @@ public class ParameterRequiredQueryHandlerTests
     public async Task Handle_CorrectParam([Values] bool required)
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
@@ -94,7 +90,7 @@ public class ParameterRequiredQueryHandlerTests
                 Name = "Param1",
                 Required = required
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
-using System.Text.Json;
 using Wiremock.OpenAPIValidator.Queries;
 
 namespace Wiremock.OpenAPIValidator.Tests.Queries;
@@ -20,7 +19,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredMissingParam()
     {
         var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -45,7 +43,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_OptionalMissingParam()
     {
         var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -70,7 +67,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamCorrectTypeEnum()
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"All\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -99,7 +95,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamIncorrectTypeEnum()
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"AAAAA\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -128,7 +123,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamEqualsToCorrectTypeDateTime()
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -157,7 +151,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamMatchesCorrectTypeUuid()
     {
         var mockedParam = "{ \"Param1\": { \"matches\": \"^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -186,7 +179,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamMatchesIncorrectTypeUuid()
     {
         var mockedParam = "{ \"Param1\": { \"matches\": \"^[{]?-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -218,7 +210,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamMatchesNotSupportedType(string format)
     {
         var mockedParam = "{ \"Param1\": { \"matches\": \"^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -249,7 +240,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_RequiredParamEqualsToIncorrectType(string format)
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -322,7 +312,6 @@ public class ParameterTypeQueryHandlerTests
     public async Task Handle_NullParam()
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";
-        var doc = JsonDocument.Parse(mockedParam);
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
@@ -265,7 +265,7 @@ public class ParameterTypeQueryHandlerTests
     }
 
     [Test]
-    public async Task Handle_NullMockedParameters_Required()
+    public async Task Handle_NullMockedParameters_WhenRequired()
     {
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -287,7 +287,7 @@ public class ParameterTypeQueryHandlerTests
     }
 
     [Test]
-    public async Task Handle_NullMockedParameters_Optional()
+    public async Task Handle_NullMockedParameters_WhenOptional()
     {
         var response = await _handler.Handle(new ParameterTypeQuery
         {

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
@@ -30,7 +30,7 @@ public class ParameterTypeQueryHandlerTests
                 Name = "Param1",
                 Required = true
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -55,7 +55,7 @@ public class ParameterTypeQueryHandlerTests
                 Name = "Param1",
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -84,7 +84,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -113,7 +113,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -142,7 +142,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -171,7 +171,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -200,7 +200,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -232,7 +232,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -263,7 +263,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -284,7 +284,7 @@ public class ParameterTypeQueryHandlerTests
         {
             Name = "UnitTest",
             Param = null,
-            MockedParameters = doc.RootElement
+            MockedParameters = mockedParam
         }, CancellationToken.None);
         Assert.That(response, Is.InstanceOf<ValidatorNode?>());
     }

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
@@ -275,6 +275,50 @@ public class ParameterTypeQueryHandlerTests
     }
 
     [Test]
+    public async Task Handle_NullMockedParameters_Required()
+    {
+        var response = await _handler.Handle(new ParameterTypeQuery
+        {
+            Name = "UnitTest",
+            Param = new OpenApiParameter
+            {
+                Name = "Param1",
+                Required = true
+            },
+            MockedParameters = null
+        }, CancellationToken.None);
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.Type, Is.EqualTo(ValidatorType.ParamType));
+            Assert.That(response.Name, Is.EqualTo("UnitTest"));
+            Assert.That(response.ValidationResult, Is.EqualTo(ValidationResult.Failed));
+            Assert.That(response.Description, Is.Not.Null.And.Contains("Param1"));
+        });
+    }
+
+    [Test]
+    public async Task Handle_NullMockedParameters_Optional()
+    {
+        var response = await _handler.Handle(new ParameterTypeQuery
+        {
+            Name = "UnitTest",
+            Param = new OpenApiParameter
+            {
+                Name = "Param1",
+                Required = false
+            },
+            MockedParameters = null
+        }, CancellationToken.None);
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.Type, Is.EqualTo(ValidatorType.ParamType));
+            Assert.That(response.Name, Is.EqualTo("UnitTest"));
+            Assert.That(response.ValidationResult, Is.EqualTo(ValidationResult.Warning));
+            Assert.That(response.Description, Is.Not.Null.And.Contains("Param1"));
+        });
+    }
+
+    [Test]
     public async Task Handle_NullParam()
     {
         var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";

--- a/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
@@ -28,8 +28,6 @@ namespace Wiremock.OpenAPIValidator.Tests
         [Test]
         public async Task SuccessfulValidation()
         {
-            
-
             _mocker.Setup<IMediator, Task<OpenApiDocument>>(x => x.Send<OpenApiDocument>(It.IsAny<OpenApiDocumentReaderCommand>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new OpenApiDocument
                 {

--- a/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
@@ -1,12 +1,6 @@
 ﻿using Microsoft.OpenApi.Models;
 using Moq;
 using Moq.AutoMock;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
 using Wiremock.OpenAPIValidator.Commands;
 using Wiremock.OpenAPIValidator.Models;
 using Wiremock.OpenAPIValidator.Queries;
@@ -41,7 +35,6 @@ namespace Wiremock.OpenAPIValidator.Tests
                .ReturnsAsync(new[] { "" });
 
             var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-            var doc = JsonDocument.Parse(mockedParam);
             var parsedMappings = new WiremockMappings
             {
                 Mappings = new List<WiremockMapping>()

--- a/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
@@ -53,7 +53,7 @@ namespace Wiremock.OpenAPIValidator.Tests
                             Request = new WiremockRequest
                             {
                                 UrlPattern = "abc",
-                                QueryParameters = doc.RootElement
+                                QueryParameters = mockedParam
                             },
                             Response = new WiremockResponse
                             {
@@ -65,7 +65,7 @@ namespace Wiremock.OpenAPIValidator.Tests
                             Request = new WiremockRequest
                             {
                                 UrlPattern = "def",
-                                QueryParameters = doc.RootElement
+                                QueryParameters = mockedParam
                             },
                             Response = new WiremockResponse
                             {
@@ -77,7 +77,7 @@ namespace Wiremock.OpenAPIValidator.Tests
                             Request = new WiremockRequest
                             {
                                 UrlPattern = "ghi",
-                                QueryParameters = doc.RootElement
+                                QueryParameters = mockedParam
                             },
                             Response = new WiremockResponse
                             {

--- a/src/Wiremock.OpenAPIValidator/Models/WiremockRequest.cs
+++ b/src/Wiremock.OpenAPIValidator/Models/WiremockRequest.cs
@@ -18,6 +18,6 @@ namespace Wiremock.OpenAPIValidator
         }
 
         [JsonPropertyName("queryParameters")]
-        public dynamic? QueryParameters { get; set; }
+        public string? QueryParameters { get; set; }
     }
 }

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
@@ -1,12 +1,14 @@
 ﻿using Microsoft.OpenApi.Models;
+using System.IO;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Wiremock.OpenAPIValidator.Queries;
 
 public class ParameterRequiredQuery : BaseQuery
 {
     public OpenApiParameter? Param { get; set; }
-    public JsonElement MockedParameters { get; set; }
+    public string MockedParameters { get; set; }
 }
 
 public class ParameterRequiredQueryHandler
@@ -17,9 +19,12 @@ public class ParameterRequiredQueryHandler
         {
             return Task.FromResult(new ValidatorNode());
         }
-        var existingProp = request.MockedParameters.TryGetProperty(request.Param.Name, out var _);
 
-        if (!existingProp && request.Param.Required)
+        var json = JsonNode.Parse(request.MockedParameters)!.AsObject();
+
+        var existingProp = json[request.Param.Name];
+
+        if (existingProp is null || existingProp.GetValue<string>() is null || request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
@@ -8,7 +8,7 @@ namespace Wiremock.OpenAPIValidator.Queries;
 public class ParameterRequiredQuery : BaseQuery
 {
     public OpenApiParameter? Param { get; set; }
-    public string MockedParameters { get; set; }
+    public string? MockedParameters { get; set; }
 }
 
 public class ParameterRequiredQueryHandler
@@ -20,11 +20,9 @@ public class ParameterRequiredQueryHandler
             return Task.FromResult(new ValidatorNode());
         }
 
-        var json = JsonNode.Parse(request.MockedParameters)!.AsObject();
+        var exists = ParameterExists(request.Param.Name, request.MockedParameters);
 
-        var existingProp = json[request.Param.Name];
-
-        if ((existingProp is null || existingProp.GetValue<string>() is null) && request.Param.Required)
+        if (!exists && request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {
@@ -34,7 +32,7 @@ public class ParameterRequiredQueryHandler
                 ValidationResult = ValidationResult.Failed
             });
         }
-        else if ((existingProp is null || existingProp.GetValue<string>() is null) && !request.Param.Required)
+        else if (!exists && !request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {
@@ -51,5 +49,15 @@ public class ParameterRequiredQueryHandler
             Type = ValidatorType.ParamRequired,
             ValidationResult = ValidationResult.Passed
         });
+    }
+
+    private static bool ParameterExists(string paramName, string? mockedParameter)
+    {
+        if (mockedParameter is null)
+        {
+            return false;
+        }
+
+        return JsonNode.Parse(mockedParameter) is JsonObject json && json.ContainsKey(paramName);
     }
 }

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.OpenApi.Models;
-using System.IO;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Wiremock.OpenAPIValidator.Queries;
@@ -20,7 +18,7 @@ public class ParameterRequiredQueryHandler
             return Task.FromResult(new ValidatorNode());
         }
 
-        var exists = ParameterExists(request.Param.Name, request.MockedParameters);
+        var exists = ParameterExistsInMock(request.Param.Name, request.MockedParameters);
 
         if (!exists && request.Param.Required)
         {
@@ -51,7 +49,7 @@ public class ParameterRequiredQueryHandler
         });
     }
 
-    private static bool ParameterExists(string paramName, string? mockedParameter)
+    private static bool ParameterExistsInMock(string paramName, string? mockedParameter)
     {
         if (mockedParameter is null)
         {

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
@@ -24,7 +24,7 @@ public class ParameterRequiredQueryHandler
 
         var existingProp = json[request.Param.Name];
 
-        if (existingProp is null || existingProp.GetValue<string>() is null || request.Param.Required)
+        if ((existingProp is null || existingProp.GetValue<string>() is null) && request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {
@@ -34,7 +34,7 @@ public class ParameterRequiredQueryHandler
                 ValidationResult = ValidationResult.Failed
             });
         }
-        else if (!existingProp && !request.Param.Required)
+        else if ((existingProp is null || existingProp.GetValue<string>() is null) && !request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
@@ -18,7 +18,7 @@ public class ParameterRequiredQueryHandler
             return Task.FromResult(new ValidatorNode());
         }
 
-        var exists = ParameterExistsInMock(request.Param.Name, request.MockedParameters);
+        var exists = MockParameterExists(request.Param.Name, request.MockedParameters);
 
         if (!exists && request.Param.Required)
         {
@@ -49,7 +49,7 @@ public class ParameterRequiredQueryHandler
         });
     }
 
-    private static bool ParameterExistsInMock(string paramName, string? mockedParameter)
+    private static bool MockParameterExists(string paramName, string? mockedParameter)
     {
         if (mockedParameter is null)
         {

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 
 namespace Wiremock.OpenAPIValidator.Queries;
@@ -8,7 +10,7 @@ namespace Wiremock.OpenAPIValidator.Queries;
 public class ParameterTypeQuery : BaseQuery
 {
     public OpenApiParameter? Param { get; set; }
-    public JsonElement MockedParameters { get; set; }
+    public string? MockedParameters { get; set; }
 }
 
 public class ParameterTypeQueryHandler
@@ -19,8 +21,9 @@ public class ParameterTypeQueryHandler
         {
             return Task.FromResult(new ValidatorNode());
         }
-        var existingProp = request.MockedParameters.TryGetProperty(request.Param.Name, out var mockedProperty);
-        if (!existingProp && request.Param.Required)
+
+        var propExists = TryParseAsObject(request.MockedParameters, out var mockedProperty);
+        if (!propExists && request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {
@@ -30,7 +33,7 @@ public class ParameterTypeQueryHandler
                 ValidationResult = ValidationResult.Failed
             });
         }
-        else if (!existingProp && !request.Param.Required)
+        else if (!propExists && !request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
             {
@@ -154,4 +157,16 @@ public class ParameterTypeQueryHandler
         "int64" => typeof(long),
         _ => throw new NotImplementedException(),
     };
+
+    private static bool TryParseAsObject(string? input, [NotNullWhen(true)] out JsonObject? json)
+    {
+        if (input is not null && JsonNode.Parse(input) is JsonObject obj)
+        {
+            json = obj;
+            return true;
+        }
+
+        json = null;
+        return false;
+    }
 }

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
@@ -23,6 +23,7 @@ public class ParameterTypeQueryHandler
         }
 
         var propExists = TryGetMockedParam(request.MockedParameters, request.Param.Name, out var mockedProperty);
+
         if (!propExists && request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
@@ -22,7 +22,7 @@ public class ParameterTypeQueryHandler
             return Task.FromResult(new ValidatorNode());
         }
 
-        var propExists = TryParseAsObject(request.MockedParameters, out var mockedProperty);
+        var propExists = TryGetMockedParam(request.MockedParameters, request.Param.Name, out var mockedProperty);
         if (!propExists && request.Param.Required)
         {
             return Task.FromResult(new ValidatorNode
@@ -158,15 +158,24 @@ public class ParameterTypeQueryHandler
         _ => throw new NotImplementedException(),
     };
 
-    private static bool TryParseAsObject(string? input, [NotNullWhen(true)] out JsonObject? json)
+    private static bool TryGetMockedParam(string? input, string paramName, [NotNullWhen(true)] out JsonObject? param)
     {
-        if (input is not null && JsonNode.Parse(input) is JsonObject obj)
+        param = null;
+
+        if (input is null)
         {
-            json = obj;
-            return true;
+            return false;
+        }
+        if (JsonNode.Parse(input) is not JsonObject outer)
+        {
+            return false;
+        }
+        if (outer[paramName] is not JsonObject inner)
+        {
+            return false;
         }
 
-        json = null;
-        return false;
+        param = inner;
+        return true;
     }
 }

--- a/src/Wiremock.OpenAPIValidator/ValidationService.cs
+++ b/src/Wiremock.OpenAPIValidator/ValidationService.cs
@@ -79,7 +79,7 @@ public class ValidationService
                     validation.Results.Add(await _mediator.Send<ValidatorNode>(new ParameterRequiredQuery
                     {
                         Name = $"{operation.OperationId} - {param.Name}",
-                        MockedParameters = (JsonElement)mapping.Request.QueryParameters,
+                        MockedParameters = mapping.Request.QueryParameters,
                         Param = param
                     }));
 

--- a/src/Wiremock.OpenAPIValidator/ValidationService.cs
+++ b/src/Wiremock.OpenAPIValidator/ValidationService.cs
@@ -84,12 +84,12 @@ public class ValidationService
                     }));
 
                     // Ensure Param Type is correct
-                    //validation.Results.Add(await _mediator.Send<ValidatorNode>(new ParameterTypeQuery
-                    //{
-                    //    Name = $"{operation.OperationId} - {param.Name}",
-                    //    MockedParameters = mapping.Request.QueryParameters,
-                    //    Param = param
-                    //}));
+                    validation.Results.Add(await _mediator.Send<ValidatorNode>(new ParameterTypeQuery
+                    {
+                        Name = $"{operation.OperationId} - {param.Name}",
+                        MockedParameters = mapping.Request.QueryParameters,
+                        Param = param
+                    }));
                 }
 
                 var mockedResponse = await _mediator.Send<Models.WiremockResponseProperties>(new WiremockResponseReaderCommand

--- a/src/Wiremock.OpenAPIValidator/ValidationService.cs
+++ b/src/Wiremock.OpenAPIValidator/ValidationService.cs
@@ -84,12 +84,12 @@ public class ValidationService
                     }));
 
                     // Ensure Param Type is correct
-                    validation.Results.Add(await _mediator.Send<ValidatorNode>(new ParameterTypeQuery
-                    {
-                        Name = $"{operation.OperationId} - {param.Name}",
-                        MockedParameters = (JsonElement)mapping.Request.QueryParameters,
-                        Param = param
-                    }));
+                    //validation.Results.Add(await _mediator.Send<ValidatorNode>(new ParameterTypeQuery
+                    //{
+                    //    Name = $"{operation.OperationId} - {param.Name}",
+                    //    MockedParameters = mapping.Request.QueryParameters,
+                    //    Param = param
+                    //}));
                 }
 
                 var mockedResponse = await _mediator.Send<Models.WiremockResponseProperties>(new WiremockResponseReaderCommand


### PR DESCRIPTION
https://github.com/tidusjar/Wiremock.OpenAPIValidator/issues/11

Fixes NullReferenceExceptions when a Wiremock mapping's `queryParameters` attribute is missing. `WiremockRequest.QueryParameters` is now `string` instead of `dynamic`, removing the unsafe `(JsonElement)` cast in `ValidationService`.