### PR TITLE
feat: add support for inline response bodies

### DIFF
--- a/src/Wiremock.OpenAPIValidator.Tests/Commands/WiremockResponseReaderCommandHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Commands/WiremockResponseReaderCommandHandlerTests.cs
@@ -1,21 +1,37 @@
-﻿using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using System.Text.Json.Nodes;
 using Wiremock.OpenAPIValidator.Commands;
+using Wiremock.OpenAPIValidator.Models;
 
 namespace Wiremock.OpenAPIValidator.Tests.Commands
 {
     public class WiremockResponseReaderCommandHandlerTests
     {
         private WiremockResponseReaderCommandHandler _handler;
+        private string _rootPath;
+        private string _mappingsPath;
+        private string _filesPath;
 
         [SetUp]
         public void Setup()
         {
             _handler = new WiremockResponseReaderCommandHandler();
+
+            // Standard WireMock layout: mappings/ and __files/ are siblings under a root.
+            _rootPath = Path.Combine(Path.GetTempPath(), $"wiremock-response-{Guid.NewGuid():N}");
+            _mappingsPath = Path.Combine(_rootPath, "mappings");
+            _filesPath = Path.Combine(_rootPath, "__files");
+            Directory.CreateDirectory(_mappingsPath);
+            Directory.CreateDirectory(_filesPath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
         }
 
         [Test]
@@ -23,12 +39,14 @@ namespace Wiremock.OpenAPIValidator.Tests.Commands
         {
             var response = await _handler.Handle(new WiremockResponseReaderCommand
             {
-                WiremockMappingPath = string.Empty
+                WiremockMappingPath = string.Empty,
+                WiremockResponse = new() { FileName = "response.json" }
             }, CancellationToken.None);
 
             Assert.Multiple(() =>
             {
                 Assert.That(response, Is.Not.Null);
+                Assert.That(response.Properties, Is.Empty);
             });
         }
 
@@ -37,12 +55,198 @@ namespace Wiremock.OpenAPIValidator.Tests.Commands
         {
             var response = await _handler.Handle(new WiremockResponseReaderCommand
             {
-                WiremockMappingPath = Directory.GetDirectoryRoot(Directory.GetCurrentDirectory())
+                WiremockMappingPath = Directory.GetDirectoryRoot(Directory.GetCurrentDirectory()),
+                WiremockResponse = new() { FileName = "response.json" }
             }, CancellationToken.None);
 
             Assert.Multiple(() =>
             {
                 Assert.That(response, Is.Not.Null);
+                Assert.That(response.Properties, Is.Empty);
+            });
+        }
+
+        [Test]
+        public async Task Handle_MissingResponseBodyFile_ReturnsEmptyProperties()
+        {
+            var response = await _handler.Handle(new WiremockResponseReaderCommand
+            {
+                WiremockMappingPath = _mappingsPath,
+                WiremockResponse = new() { FileName = "does-not-exist.json" }
+            }, CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.Properties, Is.Empty);
+            });
+        }
+
+        [Test]
+        public async Task Handle_ObjectResponseBodyFile_ReturnsObjectProperties()
+        {
+            WiremockResponse mockResponse = new();
+            var responseFileName = "object-response.json";
+            var json = """
+            {
+              "id": 1,
+              "name": "widget",
+              "inStock": true
+            }
+            """;
+            await File.WriteAllTextAsync(Path.Combine(_filesPath, responseFileName), json);
+            mockResponse.FileName = responseFileName;
+
+            var result = await _handler.Handle(new WiremockResponseReaderCommand
+            {
+                WiremockMappingPath = _mappingsPath,
+                WiremockResponse = mockResponse
+            }, CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ObjectType, Is.EqualTo(ObjectType.Object));
+                Assert.That(result.Properties, Has.Count.EqualTo(3));
+                Assert.That(result.Properties["id"], Is.EqualTo(typeof(int)));
+                Assert.That(result.Properties["name"], Is.EqualTo(typeof(string)));
+                Assert.That(result.Properties["inStock"], Is.EqualTo(typeof(bool)));
+            });
+        }
+
+        [Test]
+        public async Task Handle_ArrayResponseBodyFile_ReturnsArrayProperties()
+        {
+            WiremockResponse mockResponse = new();
+            var responseFileName = "array-response.json";
+            var json = """
+            [
+              {
+                "id": 1,
+                "name": "widget"
+              }
+            ]
+            """;
+            await File.WriteAllTextAsync(Path.Combine(_filesPath, responseFileName), json);
+
+            mockResponse.FileName = responseFileName;
+
+            var result = await _handler.Handle(new WiremockResponseReaderCommand
+            {
+                WiremockMappingPath = _mappingsPath,
+                WiremockResponse = mockResponse
+            }, CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ObjectType, Is.EqualTo(ObjectType.Array));
+                Assert.That(result.Properties, Has.Count.EqualTo(2));
+                Assert.That(result.Properties["id"], Is.EqualTo(typeof(int)));
+                Assert.That(result.Properties["name"], Is.EqualTo(typeof(string)));
+            });
+        }
+
+        [Test]
+        public async Task Handle_InlineJsonBodyObject_ReturnsObjectProperties()
+        {
+            WiremockResponse mockResponse = new()
+            {
+                JsonBody = JsonNode.Parse("""
+                {
+                  "id": 1,
+                  "name": "widget",
+                  "inStock": true
+                }
+                """)
+            };
+
+            var result = await _handler.Handle(new WiremockResponseReaderCommand
+            {
+                WiremockMappingPath = _mappingsPath,
+                WiremockResponse = mockResponse
+            }, CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ObjectType, Is.EqualTo(ObjectType.Object));
+                Assert.That(result.Properties, Has.Count.EqualTo(3));
+                Assert.That(result.Properties["id"], Is.EqualTo(typeof(int)));
+                Assert.That(result.Properties["name"], Is.EqualTo(typeof(string)));
+                Assert.That(result.Properties["inStock"], Is.EqualTo(typeof(bool)));
+            });
+        }
+
+        [Test]
+        public async Task Handle_InlineJsonBodyArray_ReturnsArrayProperties()
+        {
+            WiremockResponse mockResponse = new()
+            {
+                JsonBody = JsonNode.Parse("""
+                [
+                  {
+                    "id": 1,
+                    "name": "widget"
+                  }
+                ]
+                """)
+            };
+
+            var result = await _handler.Handle(new WiremockResponseReaderCommand
+            {
+                WiremockMappingPath = _mappingsPath,
+                WiremockResponse = mockResponse
+            }, CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ObjectType, Is.EqualTo(ObjectType.Array));
+                Assert.That(result.Properties, Has.Count.EqualTo(2));
+                Assert.That(result.Properties["id"], Is.EqualTo(typeof(int)));
+                Assert.That(result.Properties["name"], Is.EqualTo(typeof(string)));
+            });
+        }
+
+        [Test]
+        public async Task Handle_InlineJsonBodyTakesPrecedenceOverFileName()
+        {
+            // The file would yield an array; the inline body yields an object.
+            var responseFileName = "ignored-response.json";
+            await File.WriteAllTextAsync(Path.Combine(_filesPath, responseFileName), """
+            [
+              {
+                "ignored": 1
+              }
+            ]
+            """);
+
+            WiremockResponse mockResponse = new()
+            {
+                FileName = responseFileName,
+                JsonBody = JsonNode.Parse("""
+                {
+                  "id": 1,
+                  "name": "widget"
+                }
+                """)
+            };
+
+            var result = await _handler.Handle(new WiremockResponseReaderCommand
+            {
+                WiremockMappingPath = _mappingsPath,
+                WiremockResponse = mockResponse
+            }, CancellationToken.None);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ObjectType, Is.EqualTo(ObjectType.Object));
+                Assert.That(result.Properties, Has.Count.EqualTo(2));
+                Assert.That(result.Properties["id"], Is.EqualTo(typeof(int)));
+                Assert.That(result.Properties["name"], Is.EqualTo(typeof(string)));
+                Assert.That(result.Properties, Does.Not.ContainKey("ignored"));
             });
         }
     }

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterRequiredQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterRequiredQueryHandlerTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.OpenApi.Models;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using Wiremock.OpenAPIValidator.Queries;
 
 namespace Wiremock.OpenAPIValidator.Tests.Queries;
@@ -28,7 +28,7 @@ public class ParameterRequiredQueryHandlerTests
                 Name = "Param1",
                 Required = true
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -52,7 +52,7 @@ public class ParameterRequiredQueryHandlerTests
                 Name = "Param1",
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -72,7 +72,7 @@ public class ParameterRequiredQueryHandlerTests
         {
             Name = "UnitTest",
             Param = null,
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.That(response, Is.InstanceOf<ValidatorNode?>());
     }
@@ -90,7 +90,7 @@ public class ParameterRequiredQueryHandlerTests
                 Name = "Param1",
                 Required = required
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterRequiredQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterRequiredQueryHandlerTests.cs
@@ -18,7 +18,7 @@ public class ParameterRequiredQueryHandlerTests
     [Test]
     public async Task Handle_RequiredMissingParam()
     {
-        var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param2": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
@@ -42,7 +42,7 @@ public class ParameterRequiredQueryHandlerTests
     [Test]
     public async Task Handle_OptionalMissingParam()
     {
-        var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param2": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
@@ -66,7 +66,7 @@ public class ParameterRequiredQueryHandlerTests
     [Test]
     public async Task Handle_NullParam()
     {
-        var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param2": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {
@@ -80,7 +80,7 @@ public class ParameterRequiredQueryHandlerTests
     [Test]
     public async Task Handle_CorrectParam([Values] bool required)
     {
-        var mockedParam = "{ \"Param1\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param1": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterRequiredQuery
         {

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
+using System.Text.Json.Nodes;
 using Wiremock.OpenAPIValidator.Queries;
 
 namespace Wiremock.OpenAPIValidator.Tests.Queries;
@@ -28,7 +29,7 @@ public class ParameterTypeQueryHandlerTests
                 Name = "Param1",
                 Required = true
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -52,7 +53,7 @@ public class ParameterTypeQueryHandlerTests
                 Name = "Param1",
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -80,7 +81,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -108,7 +109,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -136,7 +137,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -164,7 +165,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -192,7 +193,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -223,7 +224,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -253,7 +254,7 @@ public class ParameterTypeQueryHandlerTests
                 },
                 Required = false
             },
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -317,7 +318,7 @@ public class ParameterTypeQueryHandlerTests
         {
             Name = "UnitTest",
             Param = null,
-            MockedParameters = mockedParam
+            MockedParameters = JsonNode.Parse(mockedParam)
         }, CancellationToken.None);
         Assert.That(response, Is.InstanceOf<ValidatorNode?>());
     }

--- a/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/Queries/ParameterTypeQueryHandlerTests.cs
@@ -19,7 +19,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_RequiredMissingParam()
     {
-        var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param2": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -43,7 +43,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_OptionalMissingParam()
     {
-        var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param2": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -67,7 +67,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_RequiredParamCorrectTypeEnum()
     {
-        var mockedParam = "{ \"Param1\": { \"equalTo\": \"All\" } }";
+        var mockedParam = """{ "Param1": { "equalTo": "All" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -95,7 +95,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_RequiredParamIncorrectTypeEnum()
     {
-        var mockedParam = "{ \"Param1\": { \"equalTo\": \"AAAAA\" } }";
+        var mockedParam = """{ "Param1": { "equalTo": "AAAAA" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -123,7 +123,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_RequiredParamEqualsToCorrectTypeDateTime()
     {
-        var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";
+        var mockedParam = """{ "Param1": { "equalTo": "2022-03-18T00:00:00.0000000" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -151,7 +151,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_RequiredParamMatchesCorrectTypeUuid()
     {
-        var mockedParam = "{ \"Param1\": { \"matches\": \"^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$\" } }";
+        var mockedParam = """{ "Param1": { "matches": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -179,7 +179,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_RequiredParamMatchesIncorrectTypeUuid()
     {
-        var mockedParam = "{ \"Param1\": { \"matches\": \"^[{]?-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$\" } }";
+        var mockedParam = """{ "Param1": { "matches": "^[{]?-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -210,7 +210,7 @@ public class ParameterTypeQueryHandlerTests
     [TestCase("int64")]
     public async Task Handle_RequiredParamMatchesNotSupportedType(string format)
     {
-        var mockedParam = "{ \"Param1\": { \"matches\": \"^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$\" } }";
+        var mockedParam = """{ "Param1": { "matches": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -240,7 +240,7 @@ public class ParameterTypeQueryHandlerTests
     [TestCase("int64")]
     public async Task Handle_RequiredParamEqualsToIncorrectType(string format)
     {
-        var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";
+        var mockedParam = """{ "Param1": { "equalTo": "2022-03-18T00:00:00.0000000" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {
@@ -312,7 +312,7 @@ public class ParameterTypeQueryHandlerTests
     [Test]
     public async Task Handle_NullParam()
     {
-        var mockedParam = "{ \"Param1\": { \"equalTo\": \"2022-03-18T00:00:00.0000000\" } }";
+        var mockedParam = """{ "Param1": { "equalTo": "2022-03-18T00:00:00.0000000" } }""";
 
         var response = await _handler.Handle(new ParameterTypeQuery
         {

--- a/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
@@ -1,124 +1,337 @@
-﻿using Microsoft.OpenApi.Models;
-using Moq;
-using Moq.AutoMock;
-using Wiremock.OpenAPIValidator.Commands;
-using Wiremock.OpenAPIValidator.Models;
-using Wiremock.OpenAPIValidator.Queries;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
 
 namespace Wiremock.OpenAPIValidator.Tests
 {
     public class ValidationServiceTests
     {
         private ValidationService _service;
-        private AutoMocker _mocker;
+        private string _rootPath;
+        private string _mappingsPath;
+        private string _filesPath;
+        private string _specPath;
 
         [SetUp]
         public void Setup()
         {
-            _mocker = new AutoMocker();
-            _service = _mocker.CreateInstance<ValidationService>();
+            var provider = new ServiceCollection()
+                .AddValidatorServices()
+                .BuildServiceProvider();
+            _service = provider.GetRequiredService<ValidationService>();
+
+            // Standard WireMock layout: mappings/ and __files/ are siblings under a root.
+            _rootPath = Path.Combine(Path.GetTempPath(), $"wiremock-validation-{Guid.NewGuid():N}");
+            _mappingsPath = Path.Combine(_rootPath, "mappings");
+            _filesPath = Path.Combine(_rootPath, "__files");
+            Directory.CreateDirectory(_mappingsPath);
+            Directory.CreateDirectory(_filesPath);
+            _specPath = Path.Combine(_rootPath, "openapi.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
         }
 
         [Test]
         public async Task SuccessfulValidation()
         {
-            _mocker.Setup<IMediator, Task<OpenApiDocument>>(x => x.Send<OpenApiDocument>(It.IsAny<OpenApiDocumentReaderCommand>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new OpenApiDocument
-                {
-                    Paths = new OpenApiPaths
-                    {
-                        { "/api/v1/path", new OpenApiPathItem() }
-                    }
-                });
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                new[] { QueryParam("id", required: true, format: "int32") },
+                new[] { ("id", "integer", true), ("name", "string", true) }));
 
-            _mocker.Setup<IMediator, Task<string[]>>(x => x.Send<string[]>(It.IsAny<WireMockMappingsQuery>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new[] { "" });
-
-            var mockedParam = "{ \"Param2\": { \"equalTo\": \"All\" } }";
-            var parsedMappings = new WiremockMappings
+            WriteResponseBody("widget.json", """{ "id": 1, "name": "widget" }""");
+            WriteMapping("widget.json", """
             {
-                Mappings = new List<WiremockMapping>()
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/widgets",
+                "queryParameters": { "id": { "equalTo": "1" } }
+              },
+              "response": {
+                "status": 200,
+                "bodyFileName": "widget.json"
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.That(result.Results, Is.Not.Empty);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Results.Select(r => r.ValidationResult),
+                    Is.All.EqualTo(ValidationResult.Passed));
+                // Pin the full set of checks that ran, so a silently-dropped node type is caught.
+                Assert.That(result.Results.Select(r => r.Type).Distinct(), Is.EquivalentTo(new[]
+                {
+                    ValidatorType.UrlMatch,
+                    ValidatorType.Method,
+                    ValidatorType.ParamRequired,
+                    ValidatorType.ParamType,
+                    ValidatorType.ResponsePropertyRequired,
+                    ValidatorType.ResponsePropertyType,
+                }));
+                Assert.That(result.Valid, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task InlineJsonBody_Validates()
+        {
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                parameters: null,
+                new[] { ("id", "integer", true), ("name", "string", true) }));
+
+            WriteMapping("widget.json", """
+            {
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/widgets"
+              },
+              "response": {
+                "status": 200,
+                "jsonBody": { "id": 1, "name": "widget" }
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    result.Results.Any(r => r.Type == ValidatorType.ResponsePropertyType
+                        && r.ValidationResult == ValidationResult.Passed),
+                    Is.True);
+                Assert.That(result.Valid, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task UnmatchedPath_Fails()
+        {
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                parameters: null,
+                new[] { ("id", "integer", true) }));
+
+            WriteMapping("orphan.json", """
+            {
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/nonexistent"
+              },
+              "response": {
+                "status": 200,
+                "jsonBody": { "id": 1 }
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.Multiple(() =>
+            {
+                // The unmatched path is the only failure; nothing downstream should run.
+                Assert.That(
+                    result.Results.Where(r => r.ValidationResult == ValidationResult.Failed)
+                        .Select(r => r.Type),
+                    Is.EquivalentTo(new[] { ValidatorType.UrlMatch }));
+                Assert.That(result.Valid, Is.False);
+            });
+        }
+
+        [Test]
+        public async Task MissingRequiredParam_Fails()
+        {
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                new[] { QueryParam("id", required: true, format: "int32") },
+                new[] { ("id", "integer", true) }));
+
+            WriteMapping("widget.json", """
+            {
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/widgets"
+              },
+              "response": {
+                "status": 200,
+                "jsonBody": { "id": 1 }
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.Multiple(() =>
+            {
+                // The absent required param is the only thing that fails (both param checks for it).
+                Assert.That(
+                    result.Results.Where(r => r.ValidationResult == ValidationResult.Failed)
+                        .Select(r => r.Type),
+                    Is.EquivalentTo(new[] { ValidatorType.ParamRequired, ValidatorType.ParamType }));
+                Assert.That(result.Valid, Is.False);
+            });
+        }
+
+        [Test]
+        public async Task MissingRequiredResponseProperty_Fails()
+        {
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                parameters: null,
+                new[] { ("id", "integer", true), ("name", "string", true) }));
+
+            WriteMapping("widget.json", """
+            {
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/widgets"
+              },
+              "response": {
+                "status": 200,
+                "jsonBody": { "id": 1 }
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.Multiple(() =>
+            {
+                // The missing required property is the only failure.
+                Assert.That(
+                    result.Results.Where(r => r.ValidationResult == ValidationResult.Failed)
+                        .Select(r => r.Type),
+                    Is.EquivalentTo(new[] { ValidatorType.ResponsePropertyRequired }));
+                Assert.That(result.Valid, Is.False);
+            });
+        }
+
+        [Test]
+        public async Task OptionalProperty_Warns()
+        {
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                parameters: null,
+                new[] { ("id", "integer", true), ("description", "string", false) }));
+
+            WriteMapping("widget.json", """
+            {
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/widgets"
+              },
+              "response": {
+                "status": 200,
+                "jsonBody": { "id": 1 }
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.Multiple(() =>
+            {
+                // An absent optional property warns rather than fails.
+                Assert.That(
+                    result.Results.Any(r => r.ValidationResult == ValidationResult.Failed),
+                    Is.False);
+                Assert.That(
+                    result.Results.Any(r => r.Type == ValidatorType.ResponsePropertyRequired
+                        && r.ValidationResult == ValidationResult.Warning),
+                    Is.True);
+                Assert.That(result.Valid, Is.False);
+            });
+        }
+
+        // ---- helpers ----
+
+        private void WriteSpec(OpenApiDocument document) =>
+            File.WriteAllText(_specPath, document.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0));
+
+        private void WriteMapping(string fileName, string json) =>
+            File.WriteAllText(Path.Combine(_mappingsPath, fileName), json);
+
+        private void WriteResponseBody(string fileName, string json) =>
+            File.WriteAllText(Path.Combine(_filesPath, fileName), json);
+
+        private static OpenApiParameter QueryParam(string name, bool required, string format) =>
+            new()
+            {
+                Name = name,
+                In = ParameterLocation.Query,
+                Required = required,
+                Schema = new OpenApiSchema { Type = "string", Format = format }
+            };
+
+        private static OpenApiDocument BuildSpec(
+            string path,
+            OperationType method,
+            string operationId,
+            IEnumerable<OpenApiParameter>? parameters,
+            IEnumerable<(string Name, string Type, bool Required)> responseProperties)
+        {
+            var schema = new OpenApiSchema { Type = "object" };
+            foreach (var property in responseProperties)
+            {
+                schema.Properties[property.Name] = new OpenApiSchema { Type = property.Type };
+                if (property.Required)
+                {
+                    schema.Required.Add(property.Name);
+                }
+            }
+
+            var operation = new OpenApiOperation
+            {
+                OperationId = operationId,
+                Parameters = parameters?.ToList() ?? new List<OpenApiParameter>(),
+                Responses = new OpenApiResponses
+                {
+                    ["200"] = new OpenApiResponse
                     {
-                        new WiremockMapping()
+                        Description = "OK",
+                        Content =
                         {
-                            Request = new WiremockRequest
-                            {
-                                UrlPattern = "abc",
-                                QueryParameters = mockedParam
-                            },
-                            Response = new WiremockResponse
-                            {
-                                FileName = "Test1"
-                            }
-                        },
-                        new WiremockMapping()
-                        {
-                            Request = new WiremockRequest
-                            {
-                                UrlPattern = "def",
-                                QueryParameters = mockedParam
-                            },
-                            Response = new WiremockResponse
-                            {
-                                FileName = "Test2"
-                            }
-                        },
-                        new WiremockMapping()
-                        {
-                            Request = new WiremockRequest
-                            {
-                                UrlPattern = "ghi",
-                                QueryParameters = mockedParam
-                            },
-                            Response = new WiremockResponse
-                            {
-                                FileName = "Test3"
-                            }
+                            ["application/json"] = new OpenApiMediaType { Schema = schema }
                         }
                     }
+                }
             };
-            _mocker.Setup<IMediator, Task<WiremockMappings?>>(x => x.Send<WiremockMappings?>(It.IsAny<WiremockMappingsReaderCommand>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(parsedMappings);
 
-            _mocker.Setup<IMediator, Task<UrlPathMatchResult>>(x => x.Send<UrlPathMatchResult>(It.IsAny<UrlPathMatchQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new UrlPathMatchResult
+            return new OpenApiDocument
+            {
+                Info = new OpenApiInfo { Title = "Test API", Version = "1.0.0" },
+                Paths = new OpenApiPaths
                 {
-                    ValidationNode = new ValidatorNode(),
-                    MatchedPath = new OpenApiPathItem
+                    [path] = new OpenApiPathItem
                     {
-                        Operations = new Dictionary<OperationType, OpenApiOperation> { { OperationType.Put, new OpenApiOperation {
-                            OperationId = "UnitTest",
-                            Parameters = new List<OpenApiParameter> { new OpenApiParameter {  Required = true, Name = "TestParam"} }
-                        } } }
+                        Operations = { [method] = operation }
                     }
-                });
-
-            _mocker.Setup<IMediator, Task<WiremockResponseProperties>>(x => x.Send<WiremockResponseProperties>(It.IsAny<WiremockResponseReaderCommand>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new WiremockResponseProperties());
-
-            _mocker.Setup<IMediator, Task<List<ValidatorNode>>>(x => x.Send<List<ValidatorNode>>(It.IsAny<PropertyRequiredQuery>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new List<ValidatorNode>());
-
-            _mocker.Setup<IMediator, Task<List<ValidatorNode>>>(x => x.Send<List<ValidatorNode>>(It.IsAny<PropertyTypeQuery>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(new List<ValidatorNode>());
-
-            var result = await _service.ValidateAsync("test1", "test2");
-
-            Assert.That(result, Is.Not.Null);
-
-            var mediatorMock = _mocker.GetMock<IMediator>();
-
-            mediatorMock.Verify(x => x.Send<OpenApiDocument>(It.IsAny<OpenApiDocumentReaderCommand>(), It.IsAny<CancellationToken>()), Times.Once);
-            mediatorMock.Verify(x => x.Send<string[]>(It.IsAny<WireMockMappingsQuery>(), It.IsAny<CancellationToken>()), Times.Once);
-            mediatorMock.Verify(x => x.Send<WiremockMappings?>(It.IsAny<WiremockMappingsReaderCommand>(), It.IsAny<CancellationToken>()), Times.Once);
-
-            mediatorMock.Verify(x => x.Send<UrlPathMatchResult>(It.IsAny<UrlPathMatchQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
-            mediatorMock.Verify(x => x.Send<ValidatorNode>(It.IsAny<HttpMethodQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
-            mediatorMock.Verify(x => x.Send<ValidatorNode>(It.IsAny<ParameterRequiredQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
-            mediatorMock.Verify(x => x.Send<ValidatorNode>(It.IsAny<ParameterTypeQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
-            mediatorMock.Verify(x => x.Send<WiremockResponseProperties>(It.IsAny<WiremockResponseReaderCommand>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
-            mediatorMock.Verify(x => x.Send<List<ValidatorNode>>(It.IsAny<PropertyRequiredQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
-            mediatorMock.Verify(x => x.Send<List<ValidatorNode>>(It.IsAny<PropertyTypeQuery>(), It.IsAny<CancellationToken>()), Times.Exactly(parsedMappings.Mappings.Count));
+                }
+            };
         }
     }
 }

--- a/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
+++ b/src/Wiremock.OpenAPIValidator.Tests/ValidationServiceTests.cs
@@ -193,6 +193,52 @@ namespace Wiremock.OpenAPIValidator.Tests
         }
 
         [Test]
+        public async Task NullQueryParameters_WithOptionalParam_Warns()
+        {
+            // The mapping omits the "queryParameters" block entirely, so
+            // WiremockRequest.QueryParameters deserializes to null. The param checks
+            // must run without throwing and warn (rather than fail) for an optional param.
+            WriteSpec(BuildSpec(
+                "/api/v1/widgets",
+                OperationType.Get,
+                "getWidgets",
+                new[] { QueryParam("id", required: false, format: "int32") },
+                new[] { ("id", "integer", true) }));
+
+            WriteMapping("widget.json", """
+            {
+              "request": {
+                "method": "GET",
+                "urlPattern": "/api/v1/widgets"
+              },
+              "response": {
+                "status": 200,
+                "jsonBody": { "id": 1 }
+              }
+            }
+            """);
+
+            var result = await _service.ValidateAsync(_specPath, _mappingsPath);
+
+            Assert.Multiple(() =>
+            {
+                // No check should fail when the absent param is optional.
+                Assert.That(
+                    result.Results.Any(r => r.ValidationResult == ValidationResult.Failed),
+                    Is.False);
+                // Both param checks warn for the absent optional param.
+                Assert.That(
+                    result.Results.Where(r => r.Type == ValidatorType.ParamRequired)
+                        .Select(r => r.ValidationResult),
+                    Is.EquivalentTo(new[] { ValidationResult.Warning }));
+                Assert.That(
+                    result.Results.Where(r => r.Type == ValidatorType.ParamType)
+                        .Select(r => r.ValidationResult),
+                    Is.EquivalentTo(new[] { ValidationResult.Warning }));
+            });
+        }
+
+        [Test]
         public async Task MissingRequiredResponseProperty_Fails()
         {
             WriteSpec(BuildSpec(
@@ -267,7 +313,7 @@ namespace Wiremock.OpenAPIValidator.Tests
             });
         }
 
-        // ---- helpers ----
+        #region helpers
 
         private void WriteSpec(OpenApiDocument document) =>
             File.WriteAllText(_specPath, document.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0));
@@ -332,6 +378,8 @@ namespace Wiremock.OpenAPIValidator.Tests
                     }
                 }
             };
+
+            #endregion
         }
     }
 }

--- a/src/Wiremock.OpenAPIValidator.Tests/Wiremock.OpenAPIValidator.Tests.csproj
+++ b/src/Wiremock.OpenAPIValidator.Tests/Wiremock.OpenAPIValidator.Tests.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">

--- a/src/Wiremock.OpenAPIValidator/Commands/WiremockResponseReaderCommandHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Commands/WiremockResponseReaderCommandHandler.cs
@@ -7,7 +7,7 @@ namespace Wiremock.OpenAPIValidator.Commands;
 public class WiremockResponseReaderCommand
 {
     public string WiremockMappingPath { get; set; } = string.Empty;
-    public string MockResponseFileName { get; set; } = string.Empty;
+    public WiremockResponse? WiremockResponse { get; set; }
 }
 
 public class WiremockResponseReaderCommandHandler
@@ -16,38 +16,66 @@ public class WiremockResponseReaderCommandHandler
     {
         var result = new WiremockResponseProperties();
 
-        if (!Directory.Exists(request.WiremockMappingPath))
+        if (request.WiremockResponse == null)
         {
             return Task.FromResult(result);
+        }
+
+        var responseBody = ReadResponseBody(request);
+
+        if (responseBody is null)
+        {
+            return Task.FromResult(result);
+        }
+
+        switch (responseBody.GetValueKind())
+        {
+            case JsonValueKind.Object:
+                result.ObjectType = ObjectType.Object;
+                TryAddProperty(result, responseBody.AsObject());
+                break;
+            case JsonValueKind.Array:
+                result.ObjectType = ObjectType.Array;
+                foreach (var item in responseBody.AsArray())
+                {
+                    TryAddProperty(result, item?.AsObject());
+                }
+                break;
+        }
+
+        return Task.FromResult(result);
+    }
+
+    private static JsonNode? ReadResponseBody(WiremockResponseReaderCommand request)
+    {
+        var response = request.WiremockResponse!;
+
+        if (response.JsonBody is not null)
+        {
+            return response.JsonBody;
+        }
+
+        if (string.IsNullOrEmpty(response.FileName) || !Directory.Exists(request.WiremockMappingPath))
+        {
+            return null;
         }
 
         var parentWiremock = Directory.GetParent(request.WiremockMappingPath);
 
         if (parentWiremock == null)
         {
-            return Task.FromResult(result);
-        }
-        using var responseStream = File.OpenRead(Path.Combine(parentWiremock.FullName, "__files", request.MockResponseFileName));
-        var doc = JsonDocument.Parse(responseStream);
-        if (doc.RootElement.ValueKind == JsonValueKind.Object)
-        {
-            result.ObjectType = ObjectType.Object;
-            TryAddProperty(result, doc.Deserialize<JsonObject>());
-        }
-        else if (doc.RootElement.ValueKind == JsonValueKind.Array)
-        {
-            var responseObjects = doc.Deserialize<JsonArray>();
-            result.ObjectType = ObjectType.Array;
-            if (responseObjects != null)
-            {
-                foreach (var item in responseObjects)
-                {
-                    TryAddProperty(result, item.Deserialize<JsonObject>());
-                }
-            }
+            return null;
         }
 
-        return Task.FromResult(result);
+        var responseFilePath = Path.Combine(parentWiremock.FullName, "__files", response.FileName);
+
+        if (!File.Exists(responseFilePath))
+        {
+            return null;
+        }
+
+        using var responseStream = File.OpenRead(responseFilePath);
+        return JsonNode.Parse(responseStream);
     }
 
     private static void TryAddProperty(WiremockResponseProperties result, JsonObject? responseObjects)

--- a/src/Wiremock.OpenAPIValidator/Models/WiremockRequest.cs
+++ b/src/Wiremock.OpenAPIValidator/Models/WiremockRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Wiremock.OpenAPIValidator
 {
@@ -18,6 +19,6 @@ namespace Wiremock.OpenAPIValidator
         }
 
         [JsonPropertyName("queryParameters")]
-        public string? QueryParameters { get; set; }
+        public JsonNode? QueryParameters { get; set; }
     }
 }

--- a/src/Wiremock.OpenAPIValidator/Models/WiremockResponse.cs
+++ b/src/Wiremock.OpenAPIValidator/Models/WiremockResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Wiremock.OpenAPIValidator
@@ -9,6 +10,8 @@ namespace Wiremock.OpenAPIValidator
         public HttpStatusCode Status { get; set; }
         [JsonPropertyName("bodyFileName")]
         public string FileName { get; set; } = string.Empty;
+        [JsonPropertyName("jsonBody")]
+        public JsonNode? JsonBody { get; set; }
         [JsonPropertyName("headers")]
         public WiremockHeaders? Headers { get; set; }
     }

--- a/src/Wiremock.OpenAPIValidator/Program.cs
+++ b/src/Wiremock.OpenAPIValidator/Program.cs
@@ -60,32 +60,8 @@ namespace Wiremock.OpenAPIValidator
             }
 
 
-            var services = new ServiceCollection();
-
-            // Register mediator
-            services.AddSingleton<IMediator, SimpleMediator>();
-
-            // Register all handlers
-            services.AddTransient<OpenApiDocumentReaderHandler>();
-            services.AddTransient<WiremockMappingsReaderCommandHandler>();
-            services.AddTransient<WiremockResponseReaderCommandHandler>();
-            services.AddTransient<HttpMethodQueryHandler>();
-            services.AddTransient<ParameterTypeQueryHandler>();
-            services.AddTransient<ParameterRequiredQueryHandler>();
-            services.AddTransient<PropertyTypeQueryHandler>();
-            services.AddTransient<PropertyRequiredQueryHandler>();
-            services.AddTransient<WireMockMappingsQueryHandler>();
-            services.AddTransient<ServiceInfromationQueryHandler>();
-            services.AddTransient<UrlPathMatchQueryHandler>();
-
-            // Register formatters
-            services.AddTransient<ConsoleOutputFormatter>();
-            services.AddTransient<JsonOutputFormatter>();
-            services.AddTransient<JUnitXmlOutputFormatter>();
-            services.AddTransient<GitHubActionsFormatter>();
-
-            // Register validation service
-            services.AddSingleton<ValidationService>();
+            var services = new ServiceCollection()
+                .AddValidatorServices();
 
             var provider = services.BuildServiceProvider();
             var validationService = provider.GetRequiredService<ValidationService>();

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterRequiredQueryHandler.cs
@@ -6,7 +6,7 @@ namespace Wiremock.OpenAPIValidator.Queries;
 public class ParameterRequiredQuery : BaseQuery
 {
     public OpenApiParameter? Param { get; set; }
-    public string? MockedParameters { get; set; }
+    public JsonNode? MockedParameters { get; set; }
 }
 
 public class ParameterRequiredQueryHandler
@@ -49,13 +49,8 @@ public class ParameterRequiredQueryHandler
         });
     }
 
-    private static bool MockParameterExists(string paramName, string? mockedParameter)
+    private static bool MockParameterExists(string paramName, JsonNode? mockedParameter)
     {
-        if (mockedParameter is null)
-        {
-            return false;
-        }
-
-        return JsonNode.Parse(mockedParameter) is JsonObject json && json.ContainsKey(paramName);
+        return mockedParameter is JsonObject json && json.ContainsKey(paramName);
     }
 }

--- a/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
+++ b/src/Wiremock.OpenAPIValidator/Queries/ParameterTypeQueryHandler.cs
@@ -10,7 +10,7 @@ namespace Wiremock.OpenAPIValidator.Queries;
 public class ParameterTypeQuery : BaseQuery
 {
     public OpenApiParameter? Param { get; set; }
-    public string? MockedParameters { get; set; }
+    public JsonNode? MockedParameters { get; set; }
 }
 
 public class ParameterTypeQueryHandler
@@ -159,15 +159,11 @@ public class ParameterTypeQueryHandler
         _ => throw new NotImplementedException(),
     };
 
-    private static bool TryGetMockedParam(string? input, string paramName, [NotNullWhen(true)] out JsonObject? param)
+    private static bool TryGetMockedParam(JsonNode? input, string paramName, [NotNullWhen(true)] out JsonObject? param)
     {
         param = null;
 
-        if (input is null)
-        {
-            return false;
-        }
-        if (JsonNode.Parse(input) is not JsonObject outer)
+        if (input is not JsonObject outer)
         {
             return false;
         }

--- a/src/Wiremock.OpenAPIValidator/ServiceCollectionExtensions.cs
+++ b/src/Wiremock.OpenAPIValidator/ServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wiremock.OpenAPIValidator.Commands;
+using Wiremock.OpenAPIValidator.Formatters;
+using Wiremock.OpenAPIValidator.Queries;
+
+namespace Wiremock.OpenAPIValidator;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddValidatorServices(this IServiceCollection services)
+    {
+        // Mediator
+        services.AddSingleton<IMediator, SimpleMediator>();
+
+        // Handlers
+        services.AddTransient<OpenApiDocumentReaderHandler>();
+        services.AddTransient<WiremockMappingsReaderCommandHandler>();
+        services.AddTransient<WiremockResponseReaderCommandHandler>();
+        services.AddTransient<HttpMethodQueryHandler>();
+        services.AddTransient<ParameterTypeQueryHandler>();
+        services.AddTransient<ParameterRequiredQueryHandler>();
+        services.AddTransient<PropertyTypeQueryHandler>();
+        services.AddTransient<PropertyRequiredQueryHandler>();
+        services.AddTransient<WireMockMappingsQueryHandler>();
+        services.AddTransient<ServiceInfromationQueryHandler>();
+        services.AddTransient<UrlPathMatchQueryHandler>();
+
+        // Formatters
+        services.AddTransient<ConsoleOutputFormatter>();
+        services.AddTransient<JsonOutputFormatter>();
+        services.AddTransient<JUnitXmlOutputFormatter>();
+        services.AddTransient<GitHubActionsFormatter>();
+
+        // Validation service
+        services.AddSingleton<ValidationService>();
+
+        return services;
+    }
+}

--- a/src/Wiremock.OpenAPIValidator/ValidationService.cs
+++ b/src/Wiremock.OpenAPIValidator/ValidationService.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Nodes;
-using Microsoft.OpenApi.Models;
+﻿using Microsoft.OpenApi.Models;
 using Wiremock.OpenAPIValidator.Commands;
 using Wiremock.OpenAPIValidator.Queries;
 
@@ -113,7 +111,6 @@ public class ValidationService
                     Name = operation.OperationId,
                     Responses = operation.Responses
                 }));
-
 
             }
         }

--- a/src/Wiremock.OpenAPIValidator/ValidationService.cs
+++ b/src/Wiremock.OpenAPIValidator/ValidationService.cs
@@ -94,7 +94,7 @@ public class ValidationService
 
                 var mockedResponse = await _mediator.Send<Models.WiremockResponseProperties>(new WiremockResponseReaderCommand
                 {
-                    MockResponseFileName = mapping.Response.FileName,
+                    WiremockResponse = mapping.Response,
                     WiremockMappingPath = wireMockMappings
                 });
 


### PR DESCRIPTION
feat: add support for inline response bodies

WireMock mappings can now define response bodies inline via jsonBody, in addition to the existing bodyFileName approach. The validator reads whichever is present.

Addresses https://github.com/tidusjar/Wiremock.OpenAPIValidator/issues/13